### PR TITLE
Fixed install issues in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,6 @@ from setuptools import setup
 setup(
     name="pyreason_gym",
     version="0.0.1",
+    py_modules=[],
     install_requires=["gym", "pygame", "networkx", "pyreason>=1.3.0", "numpy"],
 )


### PR DESCRIPTION
`pip install -e pyreason-gym` gave the following error:

> error: Multiple top-level packages discovered in a flat-layout: ['media', 'pyreason_gym']

Solution that worked for me:

> +    py_modules=[],

in setup.py line 6.

Verify if installation is correct when this is used.